### PR TITLE
Fixed neighbourhood name

### DIFF
--- a/data/858/978/13/85897813.geojson
+++ b/data/858/978/13/85897813.geojson
@@ -15,7 +15,7 @@
     "mps:latitude":50.076284,
     "mps:longitude":19.892324,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:is_funky":0,
     "mz:is_hard_boundary":0,
     "mz:is_landuse_aoi":0,
@@ -25,7 +25,7 @@
     "mz:tier_locality":4,
     "mz:tier_metro":30,
     "name:eng_x_preferred":[
-        "Bronowice Mae"
+        "Bronowice Male"
     ],
     "name:pol_x_colloquial":[
         "Bronowice Male"
@@ -34,9 +34,6 @@
         "Bronowice Ma\u0142e"
     ],
     "name:pol_x_variant":[
-        "Bronowice Mae"
-    ],
-    "name:unk_x_variant":[
         "Bronowice Mae"
     ],
     "qs:gn_adm0_cc":"PL",
@@ -99,7 +96,7 @@
     "wof:lang":[
         "pol"
     ],
-    "wof:lastmodified":1536864506,
+    "wof:lastmodified":1558043297,
     "wof:name":"Bronowice Male",
     "wof:parent_id":101752117,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1611.

Updates a missing `l` character in the preferred English name of a neighbourhood record in Krakow, updates a few additional properties.
No PIP work required, can merge once approved.