### PR TITLE
Update Dabrowa Gornicza, create new locality

### DIFF
--- a/data/117/561/315/9/1175613159.geojson
+++ b/data/117/561/315/9/1175613159.geojson
@@ -6,13 +6,13 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"19.2995626098,50.3456276429,19.2995626098,50.3456276429",
-    "geom:latitude":50.345628,
-    "geom:longitude":19.299563,
+    "geom:bbox":"19.188837,50.321514,19.188837,50.321514",
+    "geom:latitude":50.321514,
+    "geom:longitude":19.188837,
     "gn:population":130601,
     "iso:country":"PL",
-    "lbl:latitude":50.288906,
-    "lbl:longitude":19.245956,
+    "lbl:latitude":50.321514,
+    "lbl:longitude":19.188837,
     "lbl:max_zoom":14.0,
     "lbl:min_zoom":9.0,
     "mps:latitude":50.288906,
@@ -382,7 +382,7 @@
         1125415835
     ],
     "wof:country":"PL",
-    "wof:geomhash":"ad750a859a41d422d910cc1c31d9342a",
+    "wof:geomhash":"7e40aea622e3ef76bc38d0a896e2fb2b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -394,7 +394,7 @@
         }
     ],
     "wof:id":1175613159,
-    "wof:lastmodified":1570026051,
+    "wof:lastmodified":1573588576,
     "wof:name":"D\u0105browa G\u00f3rnicza",
     "wof:parent_id":1125411145,
     "wof:placetype":"locality",
@@ -409,10 +409,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    19.2995626097762,
-    50.3456276429304,
-    19.2995626097762,
-    50.3456276429304
+    19.188837,
+    50.321514,
+    19.188837,
+    50.321514
 ],
-  "geometry": {"coordinates":[19.2995626097762,50.3456276429304],"type":"Point"}
+  "geometry": {"coordinates":[19.188837,50.321514],"type":"Point"}
 }

--- a/data/151/109/917/7/1511099177.geojson
+++ b/data/151/109/917/7/1511099177.geojson
@@ -1,0 +1,63 @@
+{
+  "id": 1511099177,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"20.731209,52.941496,20.731209,52.941496",
+    "geom:latitude":52.941496,
+    "geom:longitude":20.731209,
+    "iso:country":"PL",
+    "lbl:latitude":52.941496,
+    "lbl:longitude":20.731209,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "Rabiez"
+    ],
+    "name:pol_x_preferred":[
+        "R\u0105bie\u017c"
+    ],
+    "src:geom":"whosonfirst",
+    "wof:belongsto":[
+        85687257,
+        102191581,
+        1477752051,
+        85633723,
+        102080055
+    ],
+    "wof:breaches":[],
+    "wof:concordances":{},
+    "wof:country":"PL",
+    "wof:geomhash":"4f42a39b8781a785f9ff216d68a55881",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633723,
+            "county_id":102080055,
+            "localadmin_id":1477752051,
+            "locality_id":1511099177,
+            "region_id":85687257
+        }
+    ],
+    "wof:id":1511099177,
+    "wof:lastmodified":1573588264,
+    "wof:name":"Rabiez",
+    "wof:parent_id":1477752051,
+    "wof:placetype":"locality",
+    "wof:repo":"whosonfirst-data-admin-pl",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    20.731209,
+    52.941496,
+    20.731209,
+    52.941496
+],
+  "geometry": {"coordinates":[20.731209,52.941496],"type":"Point"}
+}


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1738.

- Moves the geometry for Dubrowa Gornicza to the "core" of the city. Does not maintain the existing geometry to an alt geometry, as the existing geometry in a Mapshaper-based "whosonfirst" geometry.

- Creates a new record for the village of Rabiez.

PIP work is not required for this PR, can merge once approved.