### PR TITLE
Locality name updates

### DIFF
--- a/data/112/598/007/5/1125980075.geojson
+++ b/data/112/598/007/5/1125980075.geojson
@@ -23,25 +23,40 @@
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:ceb_x_preferred":[
+        "Kostkowo"
+    ],
+    "name:ceb_x_variant":[
         "Kosakowo"
     ],
     "name:deu_x_preferred":[
+        "Kostkowo"
+    ],
+    "name:deu_x_variant":[
         "Kosakowo"
     ],
     "name:fra_x_preferred":[
+        "Kostkowo"
+    ],
+    "name:fra_x_variant":[
         "Kosakowo"
     ],
     "name:nld_x_preferred":[
+        "Kostkowo"
+    ],
+    "name:nld_x_variant":[
         "Kosakowo"
     ],
     "name:pol_x_preferred":[
+        "Kostkowo"
+    ],
+    "name:pol_x_variant":[
         "Kosakowo"
     ],
     "name:ukr_x_preferred":[
-        "\u041a\u043e\u0441\u0430\u043a\u043e\u0432\u043e"
+        "\u041a\u043e\u0441\u0442\u043a\u043e\u0432\u043e"
     ],
-    "name:und_x_variant":[
-        "Kostkowo"
+    "name:ukr_x_variant":[
+        "\u041a\u043e\u0441\u0430\u043a\u043e\u0432\u043e"
     ],
     "qs_pg:aaroncc":"PL",
     "qs_pg:gn_country":"PL",
@@ -80,7 +95,8 @@
     "wof:concordances":{
         "gn:id":3095065,
         "gp:id":501381,
-        "qs_pg:id":1156153
+        "qs_pg:id":1156153,
+        "wk:page":"Kostkowo%2C_Pomeranian_Voivodeship"
     },
     "wof:country":"PL",
     "wof:created":1497298516,
@@ -96,8 +112,8 @@
         }
     ],
     "wof:id":1125980075,
-    "wof:lastmodified":1570038177,
-    "wof:name":"Kosakowo",
+    "wof:lastmodified":1574292586,
+    "wof:name":"Kostkowo",
     "wof:parent_id":1125385597,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-pl",

--- a/data/120/954/820/9/1209548209.geojson
+++ b/data/120/954/820/9/1209548209.geojson
@@ -29,8 +29,14 @@
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":12.0,
+    "name:eng_x_preferred":[
+        "\u0141uszk\u00f3w"
+    ],
+    "name:eng_x_variant":[
+        "Luszczkow"
+    ],
     "name:fra_x_preferred":[
         "\u0141uszk\u00f3w"
     ],
@@ -69,8 +75,8 @@
         }
     ],
     "wof:id":1209548209,
-    "wof:lastmodified":1570019907,
-    "wof:name":"Luszczkow",
+    "wof:lastmodified":1574292581,
+    "wof:name":"\u0141uszk\u00f3w",
     "wof:parent_id":1125392203,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-pl",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1743

- Updates names and concordances in two locality records in Poland

No PIP work required, can merge once approved.