### PR TITLE
fix dropped ł

### DIFF
--- a/data/858/978/13/85897813.geojson
+++ b/data/858/978/13/85897813.geojson
@@ -35,7 +35,7 @@
         "Bronowice Ma\u0142e"
     ],
     "name:pol_x_variant":[
-        "Bronowice Mae"
+        "Bronowice Male"
     ],
     "qs:gn_adm0_cc":"PL",
     "qs:gn_fcode":"PPL",
@@ -46,7 +46,7 @@
     "qs:local_max":40205,
     "qs:local_sum":79409,
     "qs:localhoods":6,
-    "qs:name":"Bronowice Mae",
+    "qs:name":"Bronowice Male",
     "qs:name_adm0":"Polska",
     "qs:name_adm1":"Ma\u0142opolskie",
     "qs:name_adm2":"Krak\u00f3w",


### PR DESCRIPTION
it is possible that either of this should be ł instead, but dropping l completely is a bogus data

Maybe either of this one refers to external data that is also broken and Mae should stay in such case.