### PR TITLE
Fix region translation

### DIFF
--- a/data/856/873/23/85687323.geojson
+++ b/data/856/873/23/85687323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.932196,
-    "geom:area_square_m":29711986148.469124,
+    "geom:area_square_m":29711986188.061363,
     "geom:bbox":"15.776346,51.103645,19.105,53.655869",
     "geom:latitude":52.330783,
     "geom:longitude":17.243102,
@@ -80,7 +80,6 @@
         "Greater Poland"
     ],
     "name:eng_x_variant":[
-        "Wielkopolskie",
         "Greater Poland Voivodeship"
     ],
     "name:epo_x_preferred":[
@@ -210,7 +209,7 @@
         "Voivodat di Gran Polonia"
     ],
     "name:pol_x_preferred":[
-        "Greater Poland"
+        "Wielkopolskie"
     ],
     "name:pol_x_variant":[
         "wojew\u00f3dztwo wielkopolskie"
@@ -357,7 +356,7 @@
         "deu",
         "lit"
     ],
-    "wof:lastmodified":1583882928,
+    "wof:lastmodified":1609446818,
     "wof:name":"Wielkopolskie",
     "wof:parent_id":85633723,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1801

This PR updates the English and Polish name translations in the "Greater Poland" region record. The existing name translation in the other fifteen region records in Poland look okay as-is, so I haven't included them in this PR.

No need to PIP, property edits only.