### PR TITLE
Update names for Polish neighbourhood

### DIFF
--- a/data/149/500/582/3/1495005823.geojson
+++ b/data/149/500/582/3/1495005823.geojson
@@ -22,20 +22,53 @@
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:azb_x_preferred":[
+        "\u0642\u0648\u0634\u0686\u06cc\u0686\u06cc\u0646\u0648"
+    ],
+    "name:ceb_x_preferred":[
+        "Go\u015bcicino"
+    ],
+    "name:che_x_preferred":[
+        "\u0413\u043e\u0441\u0446\u0438\u0446\u0438\u043d\u043e"
+    ],
+    "name:csb_x_preferred":[
+        "G\u00f2sc\u00ebc\u00ebno"
+    ],
     "name:eng_x_preferred":[
         "Go\u015bcicino"
     ],
+    "name:eng_x_variant":[
+        "Go\u015bcicino"
+    ],
+    "name:fas_x_preferred":[
+        "\u06af\u0648\u0634\u0686\u06cc\u0686\u06cc\u0646\u0648"
+    ],
     "name:nld_x_preferred":[
+        "Go\u015bcicino"
+    ],
+    "name:nld_x_variant":[
         "Go\u015bci\u0119cino"
     ],
     "name:pol_x_preferred":[
+        "Go\u015bcicino"
+    ],
+    "name:pol_x_variant":[
         "Go\u015bci\u0119cino"
     ],
-    "name:rus_x_preferred":[
+    "name:rus_x_variant":[
+        "\u0413\u043e\u0441\u0446\u0438\u0446\u0438\u043d\u043e"
+    ],
+    "name:tat_x_preferred":[
         "\u0413\u043e\u0441\u0446\u0438\u0446\u0438\u043d\u043e"
     ],
     "name:ukr_x_preferred":[
+        "\u0490\u043e\u0441\u0446\u0438\u0446\u0438\u043d\u043e"
+    ],
+    "name:ukr_x_variant":[
         "\u0490\u043e\u0441\u044c\u0446\u0435\u043d\u0446\u0438\u043d\u043e"
+    ],
+    "name:zho_min_nan_x_preferred":[
+        "Go\u015bcicino"
     ],
     "qs_pg:aaroncc":"PL",
     "qs_pg:gn_country":"PL",
@@ -61,12 +94,12 @@
     "woe:name_adm1":"Pomorskie",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        85687267,
         102191581,
-        1125391589,
         85633723,
-        101841907,
         102080267,
+        1125391589,
+        101841907,
+        85687267,
         101841913
     ],
     "wof:breaches":[],
@@ -99,8 +132,8 @@
         }
     ],
     "wof:id":1495005823,
-    "wof:lastmodified":1570060895,
-    "wof:name":"Go\u015bci\u0119cino",
+    "wof:lastmodified":1652295045,
+    "wof:name":"Go\u015bcicino",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:population":5278,

--- a/data/149/500/582/3/1495005823.geojson
+++ b/data/149/500/582/3/1495005823.geojson
@@ -37,9 +37,6 @@
     "name:eng_x_preferred":[
         "Go\u015bcicino"
     ],
-    "name:eng_x_variant":[
-        "Go\u015bcicino"
-    ],
     "name:fas_x_preferred":[
         "\u06af\u0648\u0634\u0686\u06cc\u0686\u06cc\u0646\u0648"
     ],
@@ -55,7 +52,7 @@
     "name:pol_x_variant":[
         "Go\u015bci\u0119cino"
     ],
-    "name:rus_x_variant":[
+    "name:rus_x_preferred":[
         "\u0413\u043e\u0441\u0446\u0438\u0446\u0438\u043d\u043e"
     ],
     "name:tat_x_preferred":[
@@ -132,7 +129,7 @@
         }
     ],
     "wof:id":1495005823,
-    "wof:lastmodified":1652295045,
+    "wof:lastmodified":1652374652,
     "wof:name":"Go\u015bcicino",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/149/500/582/3/1495005823.geojson
+++ b/data/149/500/582/3/1495005823.geojson
@@ -35,6 +35,9 @@
         "G\u00f2sc\u00ebc\u00ebno"
     ],
     "name:eng_x_preferred":[
+        "Goscicino"
+    ],
+    "name:eng_x_variant":[
         "Go\u015bcicino"
     ],
     "name:fas_x_preferred":[
@@ -129,8 +132,8 @@
         }
     ],
     "wof:id":1495005823,
-    "wof:lastmodified":1652374652,
-    "wof:name":"Go\u015bcicino",
+    "wof:lastmodified":1652913772,
+    "wof:name":"Goscicino",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:population":5278,


### PR DESCRIPTION
This PR updates names for a neighbourhood in Poland. All existing names are stored as variants, and new preferred names have been added. No PIP work needed.