### PR TITLE
Update Sosnowiec county

### DIFF
--- a/data/102/079/511/102079511.geojson
+++ b/data/102/079/511/102079511.geojson
@@ -31,17 +31,20 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:ara_x_preferred":[
+        "\u0633\u0648\u0633\u0646\u0648\u0641\u064a\u064a\u062a\u0633"
+    ],
     "name:arz_x_preferred":[
-        "\u0643\u0631\u0632\u064a\u0633\u062a\u0648\u0641 \u0628\u0631\u0632\u0648\u0632\u0648\u0641\u0633\u0643\u0649"
+        "\u0633\u0648\u0633\u0646\u0648\u0641\u064a\u064a\u062a\u0633"
     ],
     "name:ast_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
     ],
     "name:cat_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
     ],
     "name:dan_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
     ],
     "name:eng_x_historical":[
         "Sosnowice",
@@ -51,19 +54,25 @@
         "Sosnowiec"
     ],
     "name:fra_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
     ],
     "name:gle_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30bd\u30b9\u30ce\u30f4\u30a3\u30a8\u30c4"
+    ],
+    "name:kor_x_historical":[
+        "\uc18c\uc2a4\ub178\ube44\uc5d0\uce20"
     ],
     "name:nld_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
     ],
     "name:nno_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
     ],
     "name:nob_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
     ],
     "name:pol_x_historical":[
         "Sosnowice"
@@ -75,16 +84,19 @@
         "M. Sosnowiec"
     ],
     "name:slv_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
     ],
     "name:spa_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
     ],
     "name:sqi_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
     ],
     "name:swe_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
+    ],
+    "name:zho_x_preferred":[
+        "\u7d22\u65af\u8bfa\u7ef4\u8328"
     ],
     "qs:a0":"Rzeczpospolita Polska",
     "qs:a0_lc":"PL0000000",
@@ -136,11 +148,12 @@
     "wof:lang_x_spoken":[
         "pol"
     ],
-    "wof:lastmodified":1731493342,
+    "wof:lastmodified":1731555511,
     "wof:name":"Sosnowiec",
     "wof:parent_id":85687277,
     "wof:placetype":"county",
     "wof:population":185930,
+    "wof:population_rank":9,
     "wof:repo":"whosonfirst-data-admin-pl",
     "wof:superseded_by":[],
     "wof:supersedes":[],

--- a/data/102/079/511/102079511.geojson
+++ b/data/102/079/511/102079511.geojson
@@ -43,8 +43,12 @@
     "name:dan_x_preferred":[
         "Krzysztof Brzozowski"
     ],
+    "name:eng_x_historical":[
+        "Sosnowice",
+        "Sosnowitz"
+    ],
     "name:eng_x_preferred":[
-        "Krzysztof Brzozowski"
+        "Sosnowiec"
     ],
     "name:fra_x_preferred":[
         "Krzysztof Brzozowski"
@@ -61,12 +65,14 @@
     "name:nob_x_preferred":[
         "Krzysztof Brzozowski"
     ],
+    "name:pol_x_historical":[
+        "Sosnowice"
+    ],
     "name:pol_x_preferred":[
         "Sosnowiec"
     ],
     "name:pol_x_variant":[
-        "M. Sosnowiec",
-        "Krzysztof Brzozowski"
+        "M. Sosnowiec"
     ],
     "name:slv_x_preferred":[
         "Krzysztof Brzozowski"
@@ -107,14 +113,14 @@
     "wof:concordances":{
         "pl-gugik":"2475",
         "pol-gus:code":"2475",
-        "wd:id":"Q3200049"
+        "wd:id":"Q105060"
     },
     "wof:concordances_official":"pol-gus:code",
     "wof:country":"PL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5fba2c34c2d14f774374282635316d18",
+    "wof:geomhash":"8d672654b94e56087312c35d90307898",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -124,10 +130,17 @@
         }
     ],
     "wof:id":102079511,
-    "wof:lastmodified":1695886821,
+    "wof:lang_x_official":[
+        "pol"
+    ],
+    "wof:lang_x_spoken":[
+        "pol"
+    ],
+    "wof:lastmodified":1731493342,
     "wof:name":"Sosnowiec",
     "wof:parent_id":85687277,
     "wof:placetype":"county",
+    "wof:population":185930,
     "wof:repo":"whosonfirst-data-admin-pl",
     "wof:superseded_by":[],
     "wof:supersedes":[],


### PR DESCRIPTION
Replaces https://github.com/whosonfirst-data/whosonfirst-data-admin-pl/pull/56

This pull request removes bogus names, replacing them with correct names from Wikidata. A Wikidata concordance has also been added to aid future name work.

The initial bogus name seems to have come from [this issue](https://github.com/whosonfirst-data/whosonfirst-data/issues/1282), then more names added to the record over time. The new wikidata concordance should help prevent this in the future.

No PIP work required, property edits only. Number of records updated: 1