### PR TITLE
Update neighbourhood Powzki

### DIFF
--- a/data/858/980/39/85898039.geojson
+++ b/data/858/980/39/85898039.geojson
@@ -32,7 +32,8 @@
         "Powazki"
     ],
     "name:eng_x_variant":[
-        "Pow\u0105zki"
+        "Pow\u0105zki",
+        "Powzki"
     ],
     "name:fra_x_preferred":[
         "Pow\u0105zki"
@@ -66,12 +67,12 @@
     "src:lbl_centroid":"mz",
     "wd:wordcount":96,
     "wof:belongsto":[
-        102191581,
-        1125365875,
-        85633723,
-        101752777,
         1477921679,
+        102191581,
+        85633723,
         1477743805,
+        1125365875,
+        101752777,
         85687257
     ],
     "wof:breaches":[],
@@ -103,8 +104,8 @@
     "wof:lang":[
         "pol"
     ],
-    "wof:lastmodified":1690854449,
-    "wof:name":"Powzki",
+    "wof:lastmodified":1735000187,
+    "wof:name":"Powazki",
     "wof:parent_id":1477921679,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-pl",


### PR DESCRIPTION
Updating `data/858/980/39/85898039.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)

Solves https://github.com/whosonfirst-data/whosonfirst-data/issues/2223#issuecomment-2541559895 and replaces https://github.com/whosonfirst-data/whosonfirst-data-admin-pl/pull/58 so we get exportify to update the wof:lastmodified UNIX timestamp date.