### PR TITLE
Update neighbourhood Powazki

### DIFF
--- a/data/858/980/39/85898039.geojson
+++ b/data/858/980/39/85898039.geojson
@@ -29,7 +29,7 @@
         "\u041f\u0430\u0432\u043e\u043d\u0437\u043a\u0456"
     ],
     "name:eng_x_preferred":[
-        "Powazki"
+        "Pow\u0105zki"
     ],
     "name:eng_x_variant":[
         "Pow\u0105zki",
@@ -104,7 +104,7 @@
     "wof:lang":[
         "pol"
     ],
-    "wof:lastmodified":1735000187,
+    "wof:lastmodified":1748855266,
     "wof:name":"Powazki",
     "wof:parent_id":1477921679,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Updating `data/858/980/39/85898039.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)

Hello,

There are a few neighbourhoods which need their original name according to locals to be corrected, for the english names specifically, Powązki in this case would be the correct name.

I have a few more I will propose for change in next PRs using WOF editor:

Ujazdów
Służewiec
Vahi